### PR TITLE
Support "HEVC Video with Alpha" files.

### DIFF
--- a/Example/Kitsunebi/Models.swift
+++ b/Example/Kitsunebi/Models.swift
@@ -25,6 +25,9 @@ struct Resource {
   var baseVideoURL: URL { return dirURL.appendingPathComponent("/base.mp4") }
   var alphaVideoURL: URL { return dirURL.appendingPathComponent("/alpha.mp4") }
   let fps: Int = 30
+
+  @available(iOS 13.0, *)
+  var hevcWithAlphaVideoURL: URL { return dirURL.appendingPathComponent("/hevc.mov") }
 }
 
 extension Resource {
@@ -35,6 +38,13 @@ extension Resource {
   }
   
   var alphaVideoSize: CGSize? {
+    guard let track = AVAsset(url: alphaVideoURL).tracks(withMediaType: .video).first else { return nil }
+    let size = track.naturalSize.applying(track.preferredTransform)
+    return CGSize(width: abs(size.width), height: abs(size.height))
+  }
+
+  @available(iOS 13.0, *)
+  var hevcWithAlphaVideoSize: CGSize? {
     guard let track = AVAsset(url: alphaVideoURL).tracks(withMediaType: .video).first else { return nil }
     let size = track.naturalSize.applying(track.preferredTransform)
     return CGSize(width: abs(size.width), height: abs(size.height))

--- a/Example/Kitsunebi/ResourceViewController.swift
+++ b/Example/Kitsunebi/ResourceViewController.swift
@@ -94,7 +94,14 @@ extension ResourceViewController: UITableViewDelegate, UITableViewDataSource {
     let aSize = resource.alphaVideoSize
     let baseText = mSize != nil ? "Base w\(mSize!.width) x h\(mSize!.height)" : "base.mp4 not found"
     let alphaText = aSize != nil ? "Alpha: w\(aSize!.width) x h\(aSize!.height)" : "alpha.mp4 not found"
-    cell.detailTextLabel?.text = "\(baseText) / \(alphaText)"
+    var text = "\(baseText) / \(alphaText)"
+    if #available(iOS 13.0, *) {
+      let hevcWithAlphaSize = resource.hevcWithAlphaVideoSize
+      if hevcWithAlphaSize != nil {
+        text = "HEVC with Alpha: w\(hevcWithAlphaSize!.width) x h\(hevcWithAlphaSize!.height)"
+      }
+    }
+    cell.detailTextLabel?.text = text
     if let selected = selectedResource, selected.name == resource.name {
       cell.accessoryType = .checkmark
     } else {

--- a/Example/Kitsunebi/ViewController.swift
+++ b/Example/Kitsunebi/ViewController.swift
@@ -34,6 +34,12 @@ final class PreviewViewController: UIViewController {
   
   private func play() throws {
     guard let resource = currentResource else { return }
+    if #available(iOS 13.0, *) {
+      if resource.hevcWithAlphaVideoSize != nil {
+        try playerView.play(hevcWithAlpha: resource.hevcWithAlphaVideoURL, fps: resource.fps)
+        return;
+      }
+    }
     try playerView.play(base: resource.baseVideoURL, alpha: resource.alphaVideoURL, fps: resource.fps)
   }
   


### PR DESCRIPTION
This change integrates support for "HEVC Video with Alpha" files introduced in WWDC 2019 <https://developer.apple.com/videos/play/wwdc2019/506/>. (An "HEVC Video with Alpha" file is a QuickTime file that has two HEVC video layers: a base layer and an alpha layer.)
This change mainly consists of the following parts:
* [VieoEngine] change two `Asset` properties (`baseAsset` and `alphaAsset`) into an `Asset` array (`assets`):
* [AnimationView] use the alpha plane (Plane #2) if the source asset is an "HEVC Video with Alpha" file, and.
* [Example] update the example application so it can play "HEVC Video with alpha" files.
This change DOES NOT check an "HEVC Video with Alpha" asset really has an alpha layer since it requires a method available only on Xcode 12.