### PR TITLE
Delete unnecessary buffers.

### DIFF
--- a/Kitsunebi/Classes/AnimationView.swift
+++ b/Kitsunebi/Classes/AnimationView.swift
@@ -30,8 +30,6 @@ open class PlayerView: UIView {
     private let renderQueue: DispatchQueue = .global(qos: .userInitiated)
     private let commandQueue: MTLCommandQueue
     private let textureCache: CVMetalTextureCache
-    private let vertexBuffer: MTLBuffer
-    private let texCoordBuffer: MTLBuffer
     private let pipelineState: MTLRenderPipelineState
     private var applicationHandler = ApplicationHandler()
     
@@ -63,8 +61,6 @@ open class PlayerView: UIView {
         guard let pipelineState = try? device.makeRenderPipelineState(metalLib: metalLib) else { return nil }
         self.commandQueue = commandQueue
         self.textureCache = textureCache
-        self.vertexBuffer = device.makeVertexBuffer()
-        self.texCoordBuffer = device.makeTexureCoordBuffer()
         self.pipelineState = pipelineState
         super.init(frame: frame)
         applicationHandler.delegate = self
@@ -85,8 +81,6 @@ open class PlayerView: UIView {
         guard let pipelineState = try? device.makeRenderPipelineState(metalLib: metalLib) else { return nil }
         self.commandQueue = commandQueue
         self.textureCache = textureCache
-        self.vertexBuffer = device.makeVertexBuffer()
-        self.texCoordBuffer = device.makeTexureCoordBuffer()
         self.pipelineState = pipelineState
         super.init(coder: aDecoder)
         applicationHandler.delegate = self
@@ -112,8 +106,6 @@ open class PlayerView: UIView {
         
         if let commandBuffer = commandQueue.makeCommandBuffer(), let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderDesc) {
             renderEncoder.setRenderPipelineState(pipelineState)
-            renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
-            renderEncoder.setVertexBuffer(texCoordBuffer, offset: 0, index: 1)
             renderEncoder.setFragmentTexture(baseYTexture, index: 0)
             renderEncoder.setFragmentTexture(alphaYTexture, index: 1)
             renderEncoder.setFragmentTexture(baseCbCrTexture, index: 2)

--- a/Kitsunebi/Classes/default.metal
+++ b/Kitsunebi/Classes/default.metal
@@ -13,13 +13,14 @@ struct ColorInOut {
   float2 texCoords;
 };
 
-vertex ColorInOut vertexShader(const device float4 *position [[ buffer(0) ]],
-                               const device float2 *texCoords [[ buffer(1) ]],
-                               uint    vid      [[ vertex_id ]]) {
-  ColorInOut out;
-  out.position = position[vid];
-  out.texCoords = texCoords[vid];
-  return out;
+vertex ColorInOut vertexShader(uint vid [[ vertex_id ]]) {
+  const ColorInOut vertices[4] = {
+    { float4(-1.0f, -1.0f, 0.0f, 1.0f), float2(0.0f, 1.0f) },
+    { float4(1.0f, -1.0f, 0.0f, 1.0f), float2(1.0f, 1.0f) },
+    { float4(-1.0f, 1.0f, 0.0f, 1.0f), float2(0.0f, 0.0f) },
+    { float4(1.0f, 1.0f, 0.0f, 1.0f), float2(1.0f, 0.0f) },
+  };
+  return vertices[vid];
 }
 
 fragment float4 fragmentShader(ColorInOut in [[ stage_in ]],


### PR DESCRIPTION
OpenGL と異なり Metal は shader programs の中で constant variables を利用できます。
ですから、MTLBuffer の内容を変更する必要がない場合 shader constants を利用したほうがいいです。